### PR TITLE
ECMAScript 6,7,8,9 support + small fixes

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -19,6 +19,7 @@ program
     .option('-f, --file <file>', 'The file to convert and output to stdout')
     .option('-i, --input-directory <dir>', 'Source directory for original files')
     .option('-o, --output-directory <dir>', 'Destination directory for converted files')
+    .option('-e, --ecma-version <version>', 'EcmaScript version (default 6 / 2015): 6, 7, 8, 9')
     .option('--ext [ext]', 'File extension to convert. Can specify multiple extensions. Defaults to \'js\' only.', collect, [])
     .option('-v, --verbose', 'Verbose output')
     .parse(process.argv);
@@ -34,7 +35,9 @@ if (program.verbose) {
 }
 
 const Converter = require('../src');
-const converter = new Converter();
+const converter = new Converter(program.ecmaVersion && {
+    ecmaVersion: Number(program.ecmaVersion)
+});
 
 
 if (program.file) {

--- a/src/fixers/param_fixer.js
+++ b/src/fixers/param_fixer.js
@@ -108,6 +108,9 @@ class ParamFixer {
                         break;
                     }
                 }
+                else if (n.type === 'ObjectPattern' && tags.indexOf(tag) === params.indexOf(param)) {
+                    fixes.push(this.flowAnnotation.inline(n.end, tag.type, entry.resParam));
+                }
                 else if (n.type === 'RestElement') {
                     stack.push({ n: n.argument, restParam: true });
                 }

--- a/src/flow_annotation.js
+++ b/src/flow_annotation.js
@@ -34,6 +34,10 @@ function determineVarType(varType) {
         const fields = varType.fields.map(({ key, value }) => `${key}: ${determineVarType(value)}`);
         return `{ ${fields.join(', ')} }`;
     }
+    else if (varType.type === 'ArrayType') {
+        const elems = varType.elements.map(determineVarType);
+        return `Array<${elems.join(', ')}>`;
+    }
     else if (varType.type === 'NullLiteral') {
         return 'null';
     }

--- a/src/flow_annotation.js
+++ b/src/flow_annotation.js
@@ -48,6 +48,11 @@ function determineVarType(varType) {
     else if (varType.type === 'UndefinedLiteral') {
         return 'void';
     }
+    else if (varType.type === 'FunctionType') {
+        const args = varType.params.map(determineVarType);
+        const ret = determineVarType(varType.result || { type: 'UndefinedLiteral' });
+        return `(${args.join(',')}) => ${ret}`;
+    }
 
     throw new Error(`unknown '${varType.type}' type - ${JSON.stringify(varType)}`);
 }

--- a/src/flow_annotation.js
+++ b/src/flow_annotation.js
@@ -12,16 +12,18 @@ function determineVarType(varType) {
         return typeSubstitute(varType.name);
     }
     else if (varType.type === 'TypeApplication') {
-        if (varType.expression.type === 'NameExpression' &&
-            varType.applications.every(a => a.type === 'NameExpression')) {
-            const innerTypes = varType.applications.map(a => typeSubstitute(a.name)).join(',');
-            return `${typeSubstitute(varType.expression.name)}<${innerTypes}>`;
-        }
+        const parentType = typeSubstitute(varType.expression.name);
+        const innerTypes = varType.applications.map((a) => {
+            if (a.type === 'NameExpression') {
+                return typeSubstitute(a.name);
+            } else {
+                return determineVarType(a);
+            }
+        }).join(',');
+        return `${parentType}<${innerTypes}>`;
     }
     else if (varType.type === 'OptionalType' || varType.type === 'NullableType') {
-        if (varType.expression.type === 'NameExpression') {
-            return `?${typeSubstitute(varType.expression.name)}`;
-        }
+        return `?${determineVarType(varType.expression)}`;
     }
     else if (varType.type === 'AllLiteral') {
         return 'any';
@@ -40,6 +42,13 @@ function determineVarType(varType) {
         }
         return types.join(' | ');
     }
+    else if (varType.type === 'NullLiteral') {
+        return 'null';
+    }
+    else if (varType.type === 'UndefinedLiteral') {
+        return 'void';
+    }
+
     throw new Error(`unknown '${varType.type}' type - ${JSON.stringify(varType)}`);
 }
 

--- a/src/flow_annotation.js
+++ b/src/flow_annotation.js
@@ -42,16 +42,20 @@ function determineVarType(varType) {
         }
         return types.join(' | ');
     }
+    else if (varType.type === 'FunctionType') {
+        const args = varType.params.map(determineVarType);
+        const ret = determineVarType(varType.result || { type: 'UndefinedLiteral' });
+        return `(${args.join(',')}) => ${ret}`;
+    }
+    else if (varType.type === 'RecordType') {
+        const fields = varType.fields.map(({ key, value }) => `${key}: ${determineVarType(value)}`);
+        return `{ ${fields.join(', ')} }`;
+    }
     else if (varType.type === 'NullLiteral') {
         return 'null';
     }
     else if (varType.type === 'UndefinedLiteral') {
         return 'void';
-    }
-    else if (varType.type === 'FunctionType') {
-        const args = varType.params.map(determineVarType);
-        const ret = determineVarType(varType.result || { type: 'UndefinedLiteral' });
-        return `(${args.join(',')}) => ${ret}`;
     }
 
     throw new Error(`unknown '${varType.type}' type - ${JSON.stringify(varType)}`);

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,12 @@ class Converter {
         };
         this.espreeOptions.ecmaVersion = options.ecmaVersion || 6;
 
+        this.espreeOptions.ecmaFeatures = {
+            impliedStrict: true,
+            experimentalObjectRestSpread: true,
+            jsx: true,
+        };
+
         this.container = this._createContainer(options);
     }
 

--- a/src/visitor_keys.js
+++ b/src/visitor_keys.js
@@ -45,6 +45,7 @@ module.exports = {
     ArrayExpression: ["elements"],
     ArrayPattern: ["elements"],
     ArrowFunctionExpression: ["params", "body"],
+    AwaitExpression: ['argument'],
     BlockStatement: ["body"],
     BinaryExpression: ["left", "right"],
     BreakStatement: ["label"],

--- a/test/fixtures/annotated/test3.js
+++ b/test/fixtures/annotated/test3.js
@@ -1,0 +1,89 @@
+/* @flow */
+
+/**
+ * A simple class
+ *
+ * @property {string} prop1
+ * @property {number} prop2
+ */
+class MyClass {
+/*::
+prop1: string;
+prop2: number;
+*/
+
+    /**
+     * @constructs
+     * @param {string} prop1
+     * @param {?number} prop2
+     */
+    constructor(prop1 /*: string */, prop2 /*: ?number */ = 0) {
+        this.prop1 = prop1;
+        this.prop2 = prop2;
+    }
+
+    toJSON() {
+        return { ...this };
+    }
+}
+
+
+/**
+ * @param {*} whatever - A parameter
+ * @param {?Array<Array<string>>} tuples - A list of tuples
+ * @returns {undefined} nothing
+ * @throws {Error}
+ */
+function justThrow(whatever /*: any */, tuples /*: ?Array<Array<string>> */) /*: void */ {
+    throw new Error(`it throws: ${tuples.join('|')}` );
+}
+
+
+/*::
+type Secret = {
+  hash: string,
+  salt: string
+};
+*/
+/**
+ * @typedef {Object} Secret
+ * @property {string} hash
+ * @property {string} salt
+ */
+
+/**
+ * Compare a secret with something
+ *
+ * @param {string} str
+ * @param {Secret} truth
+ * @returns {boolean}
+ */
+function compare(str /*: string */, { hash, salt } /*: Secret */) /*: boolean */ {
+    return str === hash + salt;
+}
+
+/**
+ * Compare a secret with something
+ *
+ * @param {string} str
+ * @param {Object} truth
+ * @param {string} truth.hash
+ * @param {string} truth.salt
+ * @returns {boolean}
+ */
+function compare2(str /*: string */, { hash, salt } /*: { hash: string, salt: string } */) /*: boolean */ {
+    return str === hash + salt;
+}
+
+
+/**
+ * Verify something to a 3rd-party
+ *
+ * @param {string} smth
+ * @returns {Promise.<boolean>}
+ */
+async function verify(smth /*: string */) /*: Promise<boolean> */ {
+    const res = await request(() => smth);
+
+    return res.value > 0;
+}

--- a/test/fixtures/orig/test3.js
+++ b/test/fixtures/orig/test3.js
@@ -1,0 +1,79 @@
+/* @flow */
+
+/**
+ * A simple class
+ *
+ * @property {string} prop1
+ * @property {number} prop2
+ */
+class MyClass {
+
+    /**
+     * @constructs
+     * @param {string} prop1
+     * @param {?number} prop2
+     */
+    constructor(prop1, prop2 = 0) {
+        this.prop1 = prop1;
+        this.prop2 = prop2;
+    }
+
+    toJSON() {
+        return { ...this };
+    }
+}
+
+
+/**
+ * @param {*} whatever - A parameter
+ * @param {?Array<Array<string>>} tuples - A list of tuples
+ * @returns {undefined} nothing
+ * @throws {Error}
+ */
+function justThrow(whatever, tuples) {
+    throw new Error(`it throws: ${tuples.join('|')}` );
+}
+
+
+/**
+ * @typedef {Object} Secret
+ * @property {string} hash
+ * @property {string} salt
+ */
+
+/**
+ * Compare a secret with something
+ *
+ * @param {string} str
+ * @param {Secret} truth
+ * @returns {boolean}
+ */
+function compare(str, { hash, salt }) {
+    return str === hash + salt;
+}
+
+/**
+ * Compare a secret with something
+ *
+ * @param {string} str
+ * @param {Object} truth
+ * @param {string} truth.hash
+ * @param {string} truth.salt
+ * @returns {boolean}
+ */
+function compare2(str, { hash, salt }) {
+    return str === hash + salt;
+}
+
+
+/**
+ * Verify something to a 3rd-party
+ *
+ * @param {string} smth
+ * @returns {Promise.<boolean>}
+ */
+async function verify(smth) {
+    const res = await request(() => smth);
+
+    return res.value > 0;
+}

--- a/test/full_file-tests.js
+++ b/test/full_file-tests.js
@@ -4,7 +4,6 @@ require('should');
 const fs = require('fs');
 
 const Converter = require('../src');
-const converter = new Converter();
 
 const orig = `${__dirname}/fixtures/orig`;
 const annotated = `${__dirname}/fixtures/annotated`;
@@ -12,6 +11,7 @@ const annotated = `${__dirname}/fixtures/annotated`;
 describe('full file', function() {
     describe('test1', function() {
         it('should convert correctly', function() {
+            const converter = new Converter();
             const code = fs.readFileSync(`${orig}/test1.js`).toString();
             const modifiedCode = converter.convertSourceCode(code);
             const expected = fs.readFileSync(`${annotated}/test1.js`).toString();
@@ -21,9 +21,20 @@ describe('full file', function() {
 
     describe('test2', function() {
         it('should convert correctly', function() {
+            const converter = new Converter();
             const code = fs.readFileSync(`${orig}/test2.js`).toString();
             const modifiedCode = converter.convertSourceCode(code);
             const expected = fs.readFileSync(`${annotated}/test2.js`).toString();
+            modifiedCode.should.be.eql(expected);
+        });
+    });
+
+    describe('test3', function() {
+        it('should convert correctly', function() {
+            const converter = new Converter({ ecmaVersion: 8 });
+            const code = fs.readFileSync(`${orig}/test3.js`).toString();
+            const modifiedCode = converter.convertSourceCode(code);
+            const expected = fs.readFileSync(`${annotated}/test3.js`).toString();
             modifiedCode.should.be.eql(expected);
         });
     });


### PR DESCRIPTION
Hey!

Great work on this tool. I am more and more considering using it on a project as I find it very neat to leverage flow static type checking without actually bringing any new concepts to the code, and simply enforcing a correct jsdoc. 

Since I am using a rather recent version of js, I added an option to the CLI to pass an ECMAScript version to esprima. I've also fixed a bit the annotation to handle nested type declarations as well as `null` and `undefined` keywords. 

I've only applied jsdoc2flow to one of my file which contains actually quite a lot of different docstring comments and it works like a charm :) 
I'll probably submit some other PRs as apply it to the rest of the codebase.

Let me know.


